### PR TITLE
feature: images of runners are placed in menu

### DIFF
--- a/RunCat365/Program.cs
+++ b/RunCat365/Program.cs
@@ -146,6 +146,19 @@ namespace RunCat365
             cpuTimer.Start();
         }
 
+        private static Image? GetIconImageForMenu(string title)
+        {
+            Theme systemTheme = GetSystemTheme();
+            string prefix = systemTheme.GetString();
+            string iconName = $"{prefix}_{title}_0".ToLower();
+            var obj = Resources.ResourceManager.GetObject(iconName);
+            return obj switch
+            {
+                Icon icon => icon.ToBitmap(),
+                _ => null
+            } ?? null;
+        }
+
         private static ToolStripMenuItem CreateMenuFromEnum<T>(
             string title,
             Func<T, string> getTitle,
@@ -156,7 +169,8 @@ namespace RunCat365
             var items = new List<ToolStripMenuItem>();
             foreach (T value in Enum.GetValues(typeof(T)))
             {
-                var item = new ToolStripMenuItem(getTitle(value), null, onClickEvent)
+                string entityName = getTitle(value);
+                var item = new ToolStripMenuItem(entityName, GetIconImageForMenu(entityName), onClickEvent)
                 {
                     Checked = isChecked(value) 
                 };


### PR DESCRIPTION
Hello,

I made a change when creating the menu, now for the runner section the initial position icon is shown as a thumbnail image.

<img width="408" height="181" alt="image" src="https://github.com/user-attachments/assets/55a67340-8d8d-4757-ac93-fb75a03bfdbe" />

I took into account the change of removing the static in Theme and also placing the icon obtaining the default system theme. I had internal problems when doing the merge, so I pulled from another branch. I will stay tuned for updates.

Best regards,