### PR TITLE
Save default user settings when they are changed.

### DIFF
--- a/RunCat365/Program.cs
+++ b/RunCat365/Program.cs
@@ -1,4 +1,4 @@
-// Copyright 2020 Takuto Nakamura
+﻿// Copyright 2020 Takuto Nakamura
 //
 //    Licensed under the Apache License, Version 2.0 (the "License");
 //    you may not use this file except in compliance with the License.
@@ -64,7 +64,6 @@ namespace RunCat365
             _ = Enum.TryParse(UserSettings.Default.Theme, out manualTheme);
             _ = Enum.TryParse(UserSettings.Default.FPSMaxLimit, out fpsMaxLimit);
 
-            Application.ApplicationExit += new EventHandler(OnApplicationExit);
             SystemEvents.UserPreferenceChanged += new UserPreferenceChangedEventHandler(UserPreferenceChanged);
 
             cpuRepository = new CPURepository();
@@ -73,12 +72,12 @@ namespace RunCat365
 
             contextMenuManager = new ContextMenuManager(
                 () => runner,
-                r => runner = r,
+                r => ChangeRunner(r),
                 () => GetSystemTheme(),
                 () => manualTheme,
-                t => manualTheme = t,
+                t => ChangeManualTheme(t),
                 () => fpsMaxLimit,
-                f => fpsMaxLimit = f,
+                f => ChangeFPSMaxLimit(f),
                 () => OpenRepository(),
                 () => Exit()
             );
@@ -155,10 +154,24 @@ namespace RunCat365
             Application.Exit();
         }
 
-        private void OnApplicationExit(object? sender, EventArgs e)
+
+        private void ChangeRunner(Runner r)
         {
+            runner = r;
             UserSettings.Default.Runner = runner.ToString();
+            UserSettings.Default.Save();
+        }
+
+        private void ChangeManualTheme(Theme t)
+        {
+            manualTheme = t;
             UserSettings.Default.Theme = manualTheme.ToString();
+            UserSettings.Default.Save();
+        }
+
+        private void ChangeFPSMaxLimit(FPSMaxLimit f)
+        {
+            fpsMaxLimit = f;
             UserSettings.Default.FPSMaxLimit = fpsMaxLimit.ToString();
             UserSettings.Default.Save();
         }


### PR DESCRIPTION
## Type of Contribution

- [x] Bug Fix
- [ ] New Feature
- [ ] Refactoring

## Summary of the Proposal

<!-- Provide a concise summary of what this pull request proposes. -->
When the `runner`, `manualTheme` or `fpsMaxLimit` are changed, they are saved in `UserSettings.Default`

## Reason for the new feature

<!-- If it's a new feature, explain why this feature is necessary. -->
<!-- Explain how important this feature is to many users. -->
<!-- Explain if the benefits of the new feature outweigh the maintenance cost. -->
Fix #227

## Checklist

- [x] Code follows proper indentation and naming conventions.
- [x] Works correctly in both dark theme and light theme.
- [x] Works correctly on any device.
